### PR TITLE
Fixed greentea minimal-printf test for microlib

### DIFF
--- a/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
+++ b/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
@@ -857,9 +857,9 @@ static control_t test_snprintf_buffer_overflow_generic(const char *fmt, T data)
     int result_baseline;
     int result_minimal;
 #if !defined(__MICROLIB)
-    // Microlib snprintf always returns zero if the size 
+    // Microlib snprintf always returns zero if the size
     // to copy from the buffer is zero.
-    // See reported bug https://jira.arm.com/browse/SDCOMP-54710
+    // See reported microlib bug SDCOMP-54710
 
     /* empty buffer test */
     result_minimal = mbed_snprintf(buffer_minimal, 0, fmt, data);

--- a/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
+++ b/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
@@ -856,11 +856,16 @@ static control_t test_snprintf_buffer_overflow_generic(const char *fmt, T data)
     char buffer_minimal[buf_size];
     int result_baseline;
     int result_minimal;
+#if !defined(__MICROLIB)
+    // Microlib snprintf always returns zero if the size 
+    // to copy from the buffer is zero.
+    // See reported bug https://jira.arm.com/browse/SDCOMP-54710
 
     /* empty buffer test */
     result_minimal = mbed_snprintf(buffer_minimal, 0, fmt, data);
     result_baseline = snprintf(buffer_baseline, 0, fmt, data);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+#endif
 
     /* buffer isn't large enough, output needs to be truncated */
     result_minimal = mbed_snprintf(buffer_minimal, buf_size - 2, fmt, data);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
Added the !defined(__MICROLIB) guard in minimal-printf test case where snprintf() function called with zero size to skip due to the microlib snprintf() bug [https://jira.arm.com/browse/SDCOMP-54710].

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@evedon @hugueskamba 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



