### PR TITLE
Fixing the crash reporting and enable green tea test run for bare metal

### DIFF
--- a/TESTS/mbed_platform/crash_reporting/main.cpp
+++ b/TESTS/mbed_platform/crash_reporting/main.cpp
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] crash_reporting test cases require a RTOS to run.
-#else
 #include "mbed.h"
 #include "mbed_error.h"
 #include "mbed_crash_data_offsets.h"
@@ -83,4 +80,3 @@ int main(void)
 }
 
 #endif // !MBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED
-#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/platform/source/mbed_sdk_boot.c
+++ b/platform/source/mbed_sdk_boot.c
@@ -76,6 +76,7 @@ int $Super$$main(void);
 int $Sub$$main(void)
 {
     mbed_main();
+    mbed_error_initialize();
     return $Super$$main();
 }
 
@@ -109,6 +110,7 @@ void software_init_hook(void)
 int __wrap_main(void)
 {
     mbed_main();
+    mbed_error_initialize();
     return __real_main();
 }
 


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Added missing mbed_error_initialize function call in bare metal boot code which is used
to retrieve the crash report from RAM in case of any previous abnormal re-boot; this function call is present in RTOS boot code.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon @hugueskamba 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
