### PR TITLE
Add config option to set default C lib type per toolchain

### DIFF
--- a/TESTS/configs/baremetal.json
+++ b/TESTS/configs/baremetal.json
@@ -39,22 +39,40 @@
             "mbed-trace.fea-ipv6": false
         },
         "K64F": {
-            "target.default_lib": "small"
+            "target.selected_c_libs": {
+                "arm": "small",
+                "gcc_arm": "small"
+            }
         },
         "K66F": {
-            "target.default_lib": "small"
+            "target.selected_c_libs": {
+                "arm": "small",
+                "gcc_arm": "small"
+            }
         },
         "NUCLEO_F303RE": {
-            "target.default_lib": "small"
+            "target.selected_c_libs": {
+                "arm": "small",
+                "gcc_arm": "small"
+            }
         },
         "NUCLEO_F411RE": {
-            "target.default_lib": "small"
+            "target.selected_c_libs": {
+                "arm": "small",
+                "gcc_arm": "small"
+            }
         },
         "NUCLEO_F429ZI": {
-            "target.default_lib": "small"
+            "target.selected_c_libs": {
+                "arm": "small",
+                "gcc_arm": "small"
+            }
         },
         "DISCO_L475VG_IOT01A": {
-            "target.default_lib": "small"
+            "target.selected_c_libs": {
+                "arm": "small",
+                "gcc_arm": "small"
+            }
         }
      }
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -16,7 +16,6 @@
         "features": [],
         "detect_code": [],
         "public": false,
-        "default_lib": "std",
         "bootloader_supported": false,
         "static_memory_defines": true,
         "printf_lib": "std",
@@ -206,7 +205,12 @@
         "supported_toolchains": [
             "uARM"
         ],
-        "default_lib": "small"
+        "selected_c_libs": {
+            "arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"]
+        }
     },
     "CM4_ARM": {
         "inherits": [
@@ -228,7 +232,12 @@
         "supported_toolchains": [
             "uARM"
         ],
-        "default_lib": "small"
+        "selected_c_libs": {
+            "arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"]
+        }
     },
     "CM4F_ARM": {
         "inherits": [
@@ -324,10 +333,18 @@
             "SPISLAVE",
             "STDIO_MESSAGES"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC1114FN28/102"
     },
     "LPC11U24": {
@@ -376,10 +393,18 @@
             "tickless-from-us-ticker": true,
             "boot-stack-size": "0x400"
         },
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC11U24FBD48/401"
     },
     "OC_MBUINO": {
@@ -485,7 +510,14 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"]
+        },
         "device_name": "LPC11U34FBD48/311"
     },
     "MICRONFCBOARD": {
@@ -543,10 +575,18 @@
             "tickless-from-us-ticker": true,
             "boot-stack-size": "0x400"
         },
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC11U35FBD48/401"
     },
     "MCU_LPC11U35_501": {
@@ -583,7 +623,15 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC11U35FHI33/501",
         "public": false
     },
@@ -639,7 +687,15 @@
             "GCC_ARM",
             "IAR"
         ],
-        "default_lib": "small",
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC11U37FBD64/501"
     },
     "LPCCAPPUCCINO": {
@@ -700,10 +756,18 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC11U37FBD64/501"
     },
     "LPC11U68": {
@@ -741,10 +805,18 @@
         "macros": [
             "MBED_FAULT_HANDLER_DISABLED"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC11U68JBD100"
     },
     "LPC1347": {
@@ -814,10 +886,18 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC1549JBD64"
     },
     "LPC1768": {
@@ -1088,7 +1168,15 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC810M021FN8"
     },
     "LPC812": {
@@ -1124,10 +1212,18 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC812M101JDH20"
     },
     "LPC824": {
@@ -1160,10 +1256,18 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC824M201JDH20"
     },
     "SSCI824": {
@@ -1192,10 +1296,17 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
-        ]
+        ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"],
+            "gcc_arm": ["std", "small"]
+        }
     },
     "MCU_LPC4088": {
         "inherits": [
@@ -1418,10 +1529,17 @@
             "SPI",
             "SPISLAVE"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"]
+        },
         "device_name": "LPC11U37HFBD64/401"
     },
     "ELEKTOR_COCORICO": {
@@ -1443,7 +1561,15 @@
         "detect_code": [
             "C000"
         ],
-        "default_lib": "small",
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "LPC812M101JDH16"
     },
     "KL05Z": {
@@ -1484,10 +1610,18 @@
             "SPISLAVE",
             "STDIO_MESSAGES"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "MKL05Z32xxx4"
     },
     "KL25Z": {
@@ -1826,7 +1960,6 @@
             "SPISLAVE",
             "STDIO_MESSAGES"
         ],
-        "default_lib": "std",
         "release_versions": [
             "2"
         ],
@@ -2442,7 +2575,6 @@
             "FLASH",
             "WATCHDOG"
         ],
-        "default_lib": "std",
         "release_versions": [
             "2",
             "5"
@@ -2466,7 +2598,6 @@
             "USE_EXTERNAL_RTC"
         ],
         "default_toolchain": "ARM",
-        "default_lib": "std",
         "forced_reset_timeout": 7,
         "release_versions": [
             "2",
@@ -3187,10 +3318,17 @@
         "device_has_remove": [
             "LPTICKER"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32F030R8"
     },
     "NUCLEO_F031K6": {
@@ -3226,10 +3364,18 @@
         "device_has_remove": [
             "LPTICKER"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32F031K6"
     },
     "NUCLEO_F042K6": {
@@ -3266,10 +3412,18 @@
         "device_has_remove": [
             "LPTICKER"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32F042K6"
     },
     "NUCLEO_F070RB": {
@@ -3511,10 +3665,17 @@
             "CRC",
             "SERIAL_ASYNCH"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32F302R8"
     },
     "NUCLEO_F303K8": {
@@ -3540,7 +3701,14 @@
         "detect_code": [
             "0775"
         ],
-        "default_lib": "small",
+        "selected_c_libs": {
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -3673,10 +3841,17 @@
             "CRC",
             "SERIAL_ASYNCH"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32F334R8"
     },
     "NUCLEO_F401RE": {
@@ -4132,10 +4307,17 @@
         "device_has_remove": [
             "SERIAL_FC"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"]
+        },
         "device_name": "STM32F411RE"
     },
     "NUCLEO_F429ZI": {
@@ -4993,10 +5175,15 @@
             "CRC",
             "FLASH"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"]
+        },
         "device_name": "STM32L011K4"
     },
     "NUCLEO_L031K6": {
@@ -5033,10 +5220,18 @@
             "CRC",
             "FLASH"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32L031K6"
     },
     "NUCLEO_L053R8": {
@@ -5080,10 +5275,17 @@
             "FLASH",
             "MPU"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32L053R8"
     },
     "NUCLEO_L073RZ": {
@@ -5788,10 +5990,17 @@
             "CRC",
             "SERIAL_ASYNCH"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32F334C8"
     },
     "DISCO_F407VG": {
@@ -6036,10 +6245,17 @@
             "FLASH",
             "MPU"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "STM32L053C8"
     },
     "DISCO_L072CZ_LRWAN1": {
@@ -7143,7 +7359,14 @@
             "ANALOGOUT",
             "MPU"
         ],
-        "default_lib": "small",
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std", "small"],
+            "gcc_arm": ["std", "small"]
+        },
         "device_name": "STM32L151RC"
     },
     "MCU_NRF51": {
@@ -7241,7 +7464,13 @@
             "TARGET_MCU_NRF51_16K"
         ],
         "public": false,
-        "default_lib": "small"
+        "selected_c_libs": {
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["std"],
+            "gcc_arm": ["std", "small"]
+        }
     },
     "MCU_NRF51_16K_BOOT_BASE": {
         "inherits": [
@@ -9324,10 +9553,18 @@
             "uARM",
             "IAR"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "EFM32ZG222F32",
         "public": false
     },
@@ -9416,10 +9653,18 @@
             "uARM",
             "IAR"
         ],
-        "default_lib": "small",
         "release_versions": [
             "2"
         ],
+        "selected_c_libs": {
+            "arm": "small",
+            "gcc_arm": "small"
+        },
+        "supported_c_libs": {
+            "arm": ["small"],
+            "gcc_arm": ["std", "small"],
+            "iar": ["std"]
+        },
         "device_name": "EFM32HG322F64",
         "public": false
     },
@@ -10443,7 +10688,6 @@
             "SPI_ASYNCH",
             "MPU"
         ],
-        "default_lib": "std",
         "device_name": "ATSAMG55J19"
     },
     "MCU_NRF51_UNIFIED": {
@@ -11591,7 +11835,6 @@
             "SLEEP",
             "STDIO_MESSAGES"
         ],
-        "default_lib": "std",
         "release_versions": []
     },
     "SARA_NBIOT": {
@@ -14025,7 +14268,6 @@
             "smclk_div": "DIV2",
             "adc_auto_scan": 1
         },
-        "default_lib": "std",
         "release_versions": [
             "2",
             "5"

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -331,14 +331,6 @@ def is_official_target(target_name, version):
                     ("Currently it is only configured to support the ") + \
                     ("following toolchains: %s" %
                      ", ".join(sorted(supported_toolchains)))
-
-            elif not target.default_lib == 'std':
-                result = False
-                reason = ("Target '%s' must set the " % target.name) + \
-                    ("'default_lib' to 'std' to be included in the ") + \
-                    ("mbed OS 5.0 official release." + linesep) + \
-                    ("Currently it is set to '%s'" % target.default_lib)
-
         else:
             result = False
             reason = ("Target '%s' has set an invalid release version of '%s'" %

--- a/tools/config/definitions.json
+++ b/tools/config/definitions.json
@@ -98,6 +98,7 @@
           "string",
           "integer",
           "boolean",
+          "object",
           "null"
         ]
       }

--- a/tools/targets/lint.py
+++ b/tools/targets/lint.py
@@ -90,7 +90,7 @@ def check_device_has(dict):
             yield "%s is not allowed in device_has" % name
 
 MCU_REQUIRED_KEYS = ["release_versions", "supported_toolchains",
-                     "default_lib", "public", "inherits", "device_has"]
+                     "c_lib", "public", "inherits", "device_has"]
 MCU_ALLOWED_KEYS = ["device_has_add", "device_has_remove", "core",
                     "extra_labels", "features", "features_add",
                     "features_remove", "bootloader_supported", "device_name",

--- a/tools/test/build_api/build_api_test.py
+++ b/tools/test/build_api/build_api_test.py
@@ -31,7 +31,7 @@ from intelhex import IntelHex
 Tests for build_api.py
 """
 make_mock_target = namedtuple(
-    "Target", "get_post_build_hook name features core supported_toolchains build_tools_metadata")
+    "Target", "get_post_build_hook name features core supported_toolchains build_tools_metadata supported_c_libs")
 #Add ARMC5 to the supported_toolchains list as ARMC5 actually refers ARM Compiler 5 and is needed by ARM/ARM_STD classes when it checks for supported toolchains
 TOOLCHAINS.add("ARMC5")
 #Make a mock build_tools_metadata
@@ -141,8 +141,9 @@ class BuildApiTests(unittest.TestCase):
         :return:
         """
         app_config = "app_config"
+        supported_c_libs = {"arm": ["std"]}
         mock_target = make_mock_target(lambda _ : None,
-                                       "Junk", [], "Cortex-M3", TOOLCHAINS, mock_build_tools_metadata)
+                                       "Junk", [], "Cortex-M3", TOOLCHAINS, mock_build_tools_metadata, supported_c_libs)
         mock_config_init.return_value = namedtuple(
             "Config", "target has_regions name")(mock_target, False, None)
 
@@ -160,8 +161,9 @@ class BuildApiTests(unittest.TestCase):
         :param mock_config_init: mock of Config __init__
         :return:
         """
+        supported_c_libs = {"arm": ["std"]}
         mock_target = make_mock_target(lambda _ : None,
-                                       "Junk", [], "Cortex-M3", TOOLCHAINS, mock_build_tools_metadata)
+                                       "Junk", [], "Cortex-M3", TOOLCHAINS, mock_build_tools_metadata, supported_c_libs)
         mock_config_init.return_value = namedtuple(
             "Config", "target has_regions name")(mock_target, False, None)
 

--- a/tools/test/config/app_override_libs/targets.json
+++ b/tools/test/config/app_override_libs/targets.json
@@ -3,7 +3,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_toolchains": ["GCC_ARM"],
         "supported_c_libs": {
                 "arm": ["std"],

--- a/tools/test/config/compound_inheritance/targets.json
+++ b/tools/test/config/compound_inheritance/targets.json
@@ -2,7 +2,7 @@
     "base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/double_define/targets.json
+++ b/tools/test/config/double_define/targets.json
@@ -2,7 +2,7 @@
     "first_base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],
@@ -18,7 +18,7 @@
     "second_base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/feature_compesition/targets.json
+++ b/tools/test/config/feature_compesition/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/feature_recursive_add/targets.json
+++ b/tools/test/config/feature_recursive_add/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/feature_recursive_complex/targets.json
+++ b/tools/test/config/feature_recursive_complex/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/feature_remove/targets.json
+++ b/tools/test/config/feature_remove/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": ["BOOTLOADER"],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/lib_requires_missing_lib/targets.json
+++ b/tools/test/config/lib_requires_missing_lib/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/macro_inheritance/targets.json
+++ b/tools/test/config/macro_inheritance/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/override_labels_libs/targets.json
+++ b/tools/test/config/override_labels_libs/targets.json
@@ -2,7 +2,7 @@
     "base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/override_labels_libs_more/targets.json
+++ b/tools/test/config/override_labels_libs_more/targets.json
@@ -2,7 +2,7 @@
     "base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/override_labels_targets/targets.json
+++ b/tools/test/config/override_labels_targets/targets.json
@@ -2,7 +2,7 @@
     "base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/override_precidence/targets.json
+++ b/tools/test/config/override_precidence/targets.json
@@ -2,7 +2,7 @@
     "base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "core": "Cortex-M0",
         "config": {
             "par1": "v_par1_base",

--- a/tools/test/config/override_undefined/targets.json
+++ b/tools/test/config/override_undefined/targets.json
@@ -2,7 +2,7 @@
     "first_base_target": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/override_undefined_libs/targets.json
+++ b/tools/test/config/override_undefined_libs/targets.json
@@ -2,7 +2,7 @@
     "base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/override_with_labels/targets.json
+++ b/tools/test/config/override_with_labels/targets.json
@@ -2,7 +2,7 @@
     "base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/range_limits/targets.json
+++ b/tools/test/config/range_limits/targets.json
@@ -3,7 +3,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/range_limits_invalid/targets.json
+++ b/tools/test/config/range_limits_invalid/targets.json
@@ -3,7 +3,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_toolchains": ["GCC_ARM"],
         "supported_c_libs": {
                 "arm": ["std"],

--- a/tools/test/config/range_limits_override_invalid/targets.json
+++ b/tools/test/config/range_limits_override_invalid/targets.json
@@ -3,7 +3,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/requires_exclude_in_include/targets.json
+++ b/tools/test/config/requires_exclude_in_include/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],
@@ -16,7 +16,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/requires_from_lib/targets.json
+++ b/tools/test/config/requires_from_lib/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/requires_include_in_exclude/targets.json
+++ b/tools/test/config/requires_include_in_exclude/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],
@@ -16,7 +16,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/requires_omit_lib/targets.json
+++ b/tools/test/config/requires_omit_lib/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],
@@ -16,7 +16,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/simple_features/targets.json
+++ b/tools/test/config/simple_features/targets.json
@@ -4,7 +4,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/config/simple_iheritance/targets.json
+++ b/tools/test/config/simple_iheritance/targets.json
@@ -2,7 +2,7 @@
     "first_base": {
         "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
-        "default_lib": "std",
+        "c_lib": "std",
         "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/targets/target_test.py
+++ b/tools/test/targets/target_test.py
@@ -102,7 +102,7 @@ def test_modify_existing_target():
             "features": [],
             "detect_code": [],
             "public": false,
-            "default_lib": "std",
+            "c_lib": "std",
             "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],
@@ -130,7 +130,7 @@ def test_modify_existing_target():
             "features": [],
             "detect_code": [],
             "public": false,
-            "default_lib": "std",
+            "c_lib": "std",
             "supported_c_libs": {
                 "arm": ["std"],
                 "gcc_arm": ["std", "small"],

--- a/tools/test/toolchains/test_toolchains.py
+++ b/tools/test/toolchains/test_toolchains.py
@@ -31,7 +31,7 @@ class TestArmToolchain(TestCase):
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
         mock_target.printf_lib = "minimal-printf"
-        mock_target.default_lib = "std"
+        mock_target.c_lib = "std"
         mock_target.supported_c_libs = {"arm": ["std"]}
         mock_target.supported_toolchains = ["ARM", "uARM", "ARMC5"]
 
@@ -43,12 +43,12 @@ class TestArmToolchain(TestCase):
         self.assertIn("-DMBED_MINIMAL_PRINTF", arm_micro_obj.flags["common"])
         self.assertIn("-DMBED_MINIMAL_PRINTF", arm_c6_obj.flags["common"])
 
-    def test_arm_default_lib(self):
+    def test_arm_c_lib(self):
         """Test that linker flags are correctly added to an instance of ARM."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
         mock_target.supported_c_libs = {"arm": ["small"]}
-        mock_target.default_lib = "sMALL"
+        mock_target.c_lib = "sMALL"
         mock_target.default_toolchain = "ARM"
         mock_target.supported_toolchains = ["ARM", "uARM", "ARMC5", "ARMC6"]
         arm_std_obj = ARM_STD(mock_target)
@@ -68,32 +68,73 @@ class TestArmToolchain(TestCase):
         self.assertIn("-Wl,--library_type=microlib", arm_c6_obj.flags["cxx"])
         self.assertIn("--library_type=microlib", arm_c6_obj.flags["asm"])
 
-    def test_arm_default_lib_std_exception(self):
+    def test_arm_c_lib_std_exception(self):
         """Test that an exception is raised if the std C library is not supported for a target on the ARM toolchain."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
         mock_target.supported_toolchains = ["ARM", "uARM", "ARMC5"]
         mock_target.default_toolchain = "ARM"
-        mock_target.default_lib = "std"
+        mock_target.c_lib = "std"
         mock_target.supported_c_libs = {"arm": ["small"]}
-        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib)):
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib)):
             ARM_STD(mock_target)
-        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib)):
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib)):
             ARMC6(mock_target)
 
 
-    def test_arm_default_lib_small_exception(self):
+    def test_arm_c_lib_small_exception(self):
         """Test that an exception is raised if the small C library is not supported for a target on the ARM toolchain."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
-        mock_target.default_lib = "small"
+        mock_target.c_lib = "small"
         mock_target.supported_c_libs = {"arm": ["std"]}
         mock_target.default_toolchain = "ARM"
         mock_target.supported_toolchains = ["ARM", "uARM", "ARMC5"]
-        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib)):
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib)):
             ARM_STD(mock_target)
         mock_target.default_toolchain = "ARMC6"
-        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib)):
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib)):
+            ARMC6(mock_target)
+
+    def test_arm_default_small_lib_selection(self):
+        """Test that arm C library choice is used from selected_c_libs in the absence of c_lib."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        del mock_target.c_lib
+        mock_target.supported_c_libs = {"arm": ["small"]}
+        mock_target.selected_c_libs = {"arm": "small"}
+        mock_target.default_toolchain = "ARM"
+        mock_target.supported_toolchains = ["ARM", "uARM", "ARMC5", "ARMC6"]
+        arm_std_obj = ARM_STD(mock_target)
+        arm_micro_obj = ARM_MICRO(mock_target)
+
+        mock_target.default_toolchain = "ARMC6"
+        arm_c6_obj = ARMC6(mock_target)
+
+        self.assertIn("-D__MICROLIB", arm_std_obj.flags["common"])
+        self.assertIn("-D__MICROLIB", arm_micro_obj.flags["common"])
+        self.assertIn("-D__MICROLIB", arm_c6_obj.flags["common"])
+
+        self.assertIn("--library_type=microlib", arm_std_obj.flags["ld"])
+        self.assertIn("--library_type=microlib", arm_micro_obj.flags["ld"])
+        self.assertIn("--library_type=microlib", arm_c6_obj.flags["ld"])
+
+        self.assertIn("-Wl,--library_type=microlib", arm_c6_obj.flags["cxx"])
+        self.assertIn("--library_type=microlib", arm_c6_obj.flags["asm"])
+
+    def test_arm_default_std_lib_selection_not_supported_exception(self):
+        """Test that an exception is raised if the selected C library is not supported for a target on the ARM toolchain."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        del mock_target.c_lib
+        mock_target.selected_c_libs = {"arm": "std"}
+        mock_target.supported_c_libs = {"arm": "small"}
+        mock_target.default_toolchain = "ARM"
+        mock_target.supported_toolchains = ["ARM", "uARM", "ARMC5"]
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.selected_c_libs["arm"])):
+            ARM_STD(mock_target)
+        mock_target.default_toolchain = "ARMC6"
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.selected_c_libs["arm"])):
             ARMC6(mock_target)
 
 class TestGccToolchain(TestCase):
@@ -105,7 +146,7 @@ class TestGccToolchain(TestCase):
         mock_target.core = "Cortex-M4"
         mock_target.printf_lib = "minimal-printf"
         mock_target.supported_toolchains = ["GCC_ARM"]
-        mock_target.default_lib = "std"
+        mock_target.c_lib = "std"
         mock_target.supported_c_libs = {"gcc_arm": ["std"]}
         mock_target.is_TrustZone_secure_target = False
 
@@ -127,12 +168,12 @@ class TestGccToolchain(TestCase):
         for i in minimal_printf_wraps:
             self.assertIn(i, gcc_obj.flags["ld"])
 
-    def test_gcc_arm_default_lib(self):
+    def test_gcc_arm_c_lib(self):
         """Test that linker flags are correctly added to an instance of GCC_ARM."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
         mock_target.supported_c_libs = {"gcc_arm": ["small"]}
-        mock_target.default_lib = "sMALL"
+        mock_target.c_lib = "sMALL"
         mock_target.supported_toolchains = ["GCC_ARM"]
         mock_target.is_TrustZone_secure_target = False
         gcc_arm_obj = GCC_ARM(mock_target)
@@ -140,25 +181,50 @@ class TestGccToolchain(TestCase):
         self.assertIn("-D__NEWLIB_NANO", gcc_arm_obj.flags["common"])
         self.assertIn("--specs=nano.specs", gcc_arm_obj.flags["ld"])
 
-    def test_gcc_arm_default_lib_std_exception(self):
+    def test_gcc_arm_c_lib_std_exception(self):
         """Test that an exception is raised if the std C library is not supported for a target on the GCC_ARM toolchain."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
         mock_target.default_toolchain = "ARM"
-        mock_target.default_lib = "std"
-        mock_target.supported_c_libs = {"arm": ["small"]}
-        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib)):
+        mock_target.c_lib = "std"
+        mock_target.supported_c_libs = {"gcc_arm": ["small"]}
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib)):
             GCC_ARM(mock_target)
 
-    def test_gcc_arm_default_lib_small_exception(self):
+    def test_gcc_arm_c_lib_small_exception(self):
         """Test that an exception is raised if the small C library is not supported for a target on the GCC_ARM toolchain."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
-        mock_target.default_lib = "small"
-        mock_target.supported_c_libs = {"arm": ["std"]}
+        mock_target.c_lib = "small"
+        mock_target.supported_c_libs = {"gcc_arm": ["std"]}
         mock_target.default_toolchain = "ARM"
         mock_target.supported_toolchains = ["ARM", "uARM", "ARMC5"]
-        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib)):
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib)):
+            GCC_ARM(mock_target)
+
+    def test_gcc_arm_default_small_lib_selection(self):
+        """Test that gcc_arm C library choice is used from selected_c_libs in the absence of c_lib."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        mock_target.supported_c_libs = {"gcc_arm": ["small"]}
+        mock_target.selected_c_libs = {"gcc_arm": "small"}
+        del mock_target.c_lib
+        mock_target.supported_toolchains = ["GCC_ARM"]
+        mock_target.is_TrustZone_secure_target = False
+        gcc_arm_obj = GCC_ARM(mock_target)
+        self.assertIn("-DMBED_RTOS_SINGLE_THREAD", gcc_arm_obj.flags["common"])
+        self.assertIn("-D__NEWLIB_NANO", gcc_arm_obj.flags["common"])
+        self.assertIn("--specs=nano.specs", gcc_arm_obj.flags["ld"])
+
+    def test_gcc_arm_default_small_lib_selection_not_supported_exception(self):
+        """Test that an exception is raised if the selected C library is not supported for a target on the GCC_ARM toolchain."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        mock_target.default_toolchain = "ARM"
+        del mock_target.c_lib
+        mock_target.selected_c_libs = {"gcc_arm": "small"}
+        mock_target.supported_c_libs = {"gcc_arm": ["std"]}
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.selected_c_libs["gcc_arm"])):
             GCC_ARM(mock_target)
 
 class TestIarToolchain(TestCase):
@@ -170,7 +236,7 @@ class TestIarToolchain(TestCase):
         mock_target.core = "Cortex-M4"
         mock_target.printf_lib = "minimal-printf"
         mock_target.supported_toolchains = ["IAR"]
-        mock_target.default_lib = "std"
+        mock_target.c_lib = "std"
         mock_target.supported_c_libs = {"iar": ["std"]}
         mock_target.is_TrustZone_secure_target = False
 
@@ -178,35 +244,61 @@ class TestIarToolchain(TestCase):
         var = "-DMBED_MINIMAL_PRINTF"
         self.assertIn("-DMBED_MINIMAL_PRINTF", iar_obj.flags["common"])
 
-    def test_iar_default_lib(self):
+    def test_iar_c_lib(self):
         """Test that no exception is raised when a supported c library is specified."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
         mock_target.supported_c_libs = {"iar": ["std"]}
-        mock_target.default_lib = "sTD"
+        mock_target.c_lib = "sTD"
         mock_target.supported_toolchains = ["IAR"]
         mock_target.is_TrustZone_secure_target = False
         try:
             IAR(mock_target)
         except NotSupportedException:
-            self.fail(UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib))
+            self.fail(UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib))
 
-    def test_iar_default_lib_std_exception(self):
+    def test_iar_c_lib_std_exception(self):
         """Test that an exception is raised if the std C library is not supported for a target on the IAR toolchain."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
-        mock_target.default_lib = "std"
+        mock_target.c_lib = "std"
         mock_target.supported_c_libs = {"iar": ["small"]}
         mock_target.supported_toolchains = ["IAR"]
-        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib)):
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib)):
             IAR(mock_target)
 
-    def test_iar_default_lib_small_exception(self):
+    def test_iar_c_lib_small_exception(self):
         """Test that an exception is raised if the small C library is not supported for a target on the IAR toolchain."""
         mock_target = mock.MagicMock()
         mock_target.core = "Cortex-M4"
-        mock_target.default_lib = "small"
+        mock_target.c_lib = "small"
         mock_target.supported_c_libs = {"iar": ["std"]}
         mock_target.supported_toolchains = ["IAR"]
-        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.default_lib)):
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.c_lib)):
+            IAR(mock_target)
+
+    def test_iar_default_std_lib_selection(self):
+        """Test that iar C library choice is used from selected_c_libs in the absence of c_lib."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        mock_target.supported_c_libs = {"iar": ["std"]}
+        del mock_target.c_lib
+        mock_target.selected_c_libs = {"iar": "std"}
+        mock_target.supported_toolchains = ["IAR"]
+        mock_target.is_TrustZone_secure_target = False
+        try:
+            IAR(mock_target)
+        except NotSupportedException:
+            self.fail(UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.selected_c_libs["iar"]))
+
+    def test_iar_default_std_lib_selection_not_supported_exception(self):
+        """Test that an exception is raised if the selected C library is not supported for a target on the IAR toolchain."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        mock_target.microlib_supported = False
+        del mock_target.c_lib
+        mock_target.selected_c_libs = {"iar": "std"}
+        mock_target.supported_c_libs = {"iar": ["small"]}
+        mock_target.supported_toolchains = ["IAR"]
+        with self.assertRaisesRegexp(NotSupportedException, UNSUPPORTED_C_LIB_EXCEPTION_STRING.format(mock_target.selected_c_libs["iar"])):
             IAR(mock_target)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -77,11 +77,12 @@ class ARM(mbedToolchain):
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
 
-        self.check_c_lib_supported(target, "arm")
+        c_lib = self.get_c_lib_config(target, "arm")
+        self.check_c_lib_supported(target, "arm", c_lib)
 
         if (
             getattr(target, "default_toolchain", "ARM") == "uARM"
-            or getattr(target, "default_lib", "std") == "small"
+            or c_lib == "small"
         ):
             if "-DMBED_RTOS_SINGLE_THREAD" not in self.flags['common']:
                 self.flags['common'].append("-DMBED_RTOS_SINGLE_THREAD")
@@ -567,11 +568,12 @@ class ARMC6(ARM_STD):
                     "ARM/ARMC6 compiler support is required for ARMC6 build"
                 )
 
-        self.check_c_lib_supported(target, "arm")
+        c_lib = self.get_c_lib_config(target, "arm")
+        self.check_c_lib_supported(target, "arm", c_lib)
 
         if (
             getattr(target, "default_toolchain", "ARMC6") == "uARM"
-            or getattr(target, "default_lib", "std") == "small"
+            or c_lib == "small"
         ):
             if "-DMBED_RTOS_SINGLE_THREAD" not in self.flags['common']:
                 self.flags['common'].append("-DMBED_RTOS_SINGLE_THREAD")

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -47,15 +47,11 @@ class GCC(mbedToolchain):
         )
 
         tool_path = TOOLCHAIN_PATHS['GCC_ARM']
-        # Add flags for current size setting
-        default_lib = "std"
-        if hasattr(target, "default_lib"):
-            self.check_c_lib_supported(target, "gcc_arm")
-            default_lib = target.default_lib
-        elif hasattr(target, "default_build"):
-            default_lib = target.default_build
 
-        if default_lib == "small":
+        c_lib = self.get_c_lib_config(target, "gcc_arm")
+        self.check_c_lib_supported(target, "gcc_arm", c_lib)
+
+        if c_lib == "small":
             common_flags = ["-DMBED_RTOS_SINGLE_THREAD", "-D__NEWLIB_NANO"]
             self.flags["common"].extend(common_flags)
             self.flags["ld"].append("--specs=nano.specs")

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -53,7 +53,8 @@ class IAR(mbedToolchain):
             build_profile=build_profile
         )
 
-        self.check_c_lib_supported(target, "iar")
+        c_lib = self.get_c_lib_config(target, "iar")
+        self.check_c_lib_supported(target, "iar", c_lib)
 
         if target.is_TrustZone_secure_target:
             # Enable compiler security extensions


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The `target.default_lib` configuration is used for C library selection (choice of "std" or "small"). As part of enabling small libraries for baremetal, this option which previously was only supported by GCC_ARM was made generic to all toolchains. This introduced the following regressions: 
- targets which have `"default_lib" : "small"` in targets.json no longer compile with IAR as there is no support for a small library with IAR. 

The proposed solution is to add a new `selected_c_libs` target configuration which is toolchain specific. `default_lib` (renamed to `c_lib`) is left unchanged i.e. generic for all toolchains and is an application configuration that takes precedence over `selected_c_libs`. This means that the change introduced in this PR is transparent to the user.

- targets which have "default_lib": "small" in targets.json no longer compile with ARM as default supported_c_libs are not having "small" in the C library configuration for this toolchain.

The proposed solution is,  if the target configuration `"supported_toolchains"` and `"default_toolchain"`  has `"uARM"`, then overwrite `supported_c_libs  "arm"` C library configuration with "small".

Other changes:
- Renamed `default_lib` to `c_lib`. 
- Fixed IAR compilation failures for baremetal greentea tests by using `selected_c_libs` in `baremetal.json`. 
- Added build tool test cases for the new target configuration parameter.

#### More details
Example: LPC1114 target. This target was configured with `"target.default_lib": "small"`  in targets.json; this is replaced with:
```
"selected_c_libs": {
            "arm": "small",
            "gcc_arm": "small"
}
```
 - `"arm": "small"` because `default_toolchain` is uARM.
 - `"gcc_arm": "small"` because  "default_lib" is set to "small" ("default_lib" used to only apply to gcc_arm).

and also overwrite with:
```
 "supported_c_libs": {
       "arm": ["std", "small"],
        "gcc_arm": ["std", "small"],
        "iar": ["std"]
}
```
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@hugueskamba @evedon 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
