### PR TITLE
CMake: Build unittest from mbed-os root directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@
 
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
+if(${CMAKE_UNIT_TESTING})
+    set(PROJECT_NAME unittests)    
+    project(${PROJECT_NAME})
+    add_subdirectory(UNITTESTS)
+else()
 include(${MBED_CONFIG_PATH}/mbed_config.cmake)
 
 add_library(mbed-core INTERFACE)
@@ -244,4 +249,5 @@ if ("${CMAKE_GENERATOR}" MATCHES "Ninja")
     if(NOT (CMAKE_HOST_SYSTEM_NAME MATCHES "Windows" AND CMAKE_CXX_COMPILER_ID MATCHES "ARMClang"))
         set(CMAKE_NINJA_FORCE_RESPONSE_FILE 1 CACHE INTERNAL "")
     endif()
+endif()
 endif()

--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -1,24 +1,8 @@
-cmake_minimum_required(VERSION 3.0.2)
-
-set(PROJECT_NAME unittests)
 set(LIB_NAME MbedOS)
 
-project(${PROJECT_NAME})
-
 # Setup c++ standard
-macro(use_cxx14)
-    if (CMAKE_VERSION VERSION_LESS 3.1)
-        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14")
-        endif()
-    else()
-        set(CMAKE_CXX_STANDARD 14)
-        set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    endif()
-endmacro()
-
-use_cxx14()
-
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (MINGW)
   # enable PRIx formatting globally
@@ -26,41 +10,24 @@ if (MINGW)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS")
 endif (MINGW)
 
+find_package(Threads)
+
 ####################
 # GTEST
 ####################
-
-# Download and unpack googletest at configure time
-configure_file(googletest-CMakeLists.txt.in googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-    RESULT_VARIABLE result
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
-if (result)
-    message(FATAL_ERROR "CMake failed for google test: ${result}")
-endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-    RESULT_VARIABLE result
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
-if (result)
-    message(FATAL_ERROR "Build failed for google test: ${result}")
+include(FetchContent)
+# Download and unpack googletest
+if(NOT GTEST_FOUND)
+    FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG release-1.10.0
+    )
+    FetchContent_MakeAvailable(googletest)
 endif()
 
 # Prevent overriding the parent project's compiler/linker
 # settings on Windows
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-# Add googletest directly to our build. This defines
-# the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
-                 ${CMAKE_BINARY_DIR}/googletest-build
-                 EXCLUDE_FROM_ALL)
-
-# The gtest/gtest_main/gmock/gmock_main targets carry header search path
-# dependencies automatically when using CMake 2.8.11 or
-# later.
-target_include_directories(gmock_main SYSTEM BEFORE INTERFACE
-  "$<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>"
-  "$<BUILD_INTERFACE:${gmock_SOURCE_DIR}/include>")
 
 ####################
 # TESTING
@@ -102,62 +69,62 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUNITTEST")
 
 # Set include dirs.
 set(unittest-includes-base
-  "${PROJECT_SOURCE_DIR}/target_h"
-  "${PROJECT_SOURCE_DIR}/../events/tests/UNITTESTS/target_h"
-  "${PROJECT_SOURCE_DIR}/../events/tests/UNITTESTS/target_h/equeue"
-  "${PROJECT_SOURCE_DIR}/target_h/platform"
-  "${PROJECT_SOURCE_DIR}/target_h/platform/cxxsupport"
-  "${PROJECT_SOURCE_DIR}/target_h/drivers"
-  "${PROJECT_SOURCE_DIR}/target_h/rtos/include"
-  "${PROJECT_SOURCE_DIR}/stubs"
-  "${PROJECT_SOURCE_DIR}/.."
-  "${PROJECT_SOURCE_DIR}/../features"
-  "${PROJECT_SOURCE_DIR}/../platform/include"
-  "${PROJECT_SOURCE_DIR}/../platform/include/platform"
-  "${PROJECT_SOURCE_DIR}/../platform/mbed-trace/include"
-  "${PROJECT_SOURCE_DIR}/../storage/filesystem/littlefs/include"
-  "${PROJECT_SOURCE_DIR}/../storage/filesystem/fat/include"
-  "${PROJECT_SOURCE_DIR}/../storage/blockdevice/include"
-  "${PROJECT_SOURCE_DIR}/../storage/filesystem/include"
-  "${PROJECT_SOURCE_DIR}/../storage/kvstore/include"
-  "${PROJECT_SOURCE_DIR}/../storage/kvstore/kv_config"
-  "${PROJECT_SOURCE_DIR}/../storage/kvstore/kv_config/include"
-  "${PROJECT_SOURCE_DIR}/../storage/kvstore/tdbstore/include"
-  "${PROJECT_SOURCE_DIR}/../storage/kvstore/filesystemstore/include"
-  "${PROJECT_SOURCE_DIR}/../storage/kvstore/kvstore_global_api/include"
-  "${PROJECT_SOURCE_DIR}/../drivers"
-  "${PROJECT_SOURCE_DIR}/../drivers/include"
-  "${PROJECT_SOURCE_DIR}/../drivers/include/drivers"
-  "${PROJECT_SOURCE_DIR}/../drivers/include/drivers/internal"
-  "${PROJECT_SOURCE_DIR}/../hal"
-  "${PROJECT_SOURCE_DIR}/../hal/include"
-  "${PROJECT_SOURCE_DIR}/../events/include"
-  "${PROJECT_SOURCE_DIR}/../events/include/events/internal"
-  "${PROJECT_SOURCE_DIR}/../events/source"
-  "${PROJECT_SOURCE_DIR}/../rtos/include"
-  "${PROJECT_SOURCE_DIR}/../features/frameworks"
-  "${PROJECT_SOURCE_DIR}/../connectivity/libraries/nanostack-libservice"
-  "${PROJECT_SOURCE_DIR}/../connectivity/libraries/nanostack-libservice/mbed-client-libservice"
-  "${PROJECT_SOURCE_DIR}/../connectivity/netsocket/include"
-  "${PROJECT_SOURCE_DIR}/../features/filesystem/fat"
-  "${PROJECT_SOURCE_DIR}/../features/filesystem/fat/ChaN"
-  "${PROJECT_SOURCE_DIR}/../features/filesystem/bd"
-  "${PROJECT_SOURCE_DIR}/../features/filesystem/"
-  "${PROJECT_SOURCE_DIR}/../features/filesystem/littlefs"
-  "${PROJECT_SOURCE_DIR}/../features/filesystem/littlefs/littlefs"
-  "${PROJECT_SOURCE_DIR}/../connectivity/cellular/include/cellular/framework/API"
-  "${PROJECT_SOURCE_DIR}/../connectivity/cellular/include/cellular/framework/AT"
-  "${PROJECT_SOURCE_DIR}/../connectivity/cellular/include/cellular/framework/device"
-  "${PROJECT_SOURCE_DIR}/../connectivity/cellular/include/cellular/framework"
-  "${PROJECT_SOURCE_DIR}/../connectivity/cellular/include/cellular/framework/common"
-  "${PROJECT_SOURCE_DIR}/../connectivity"
-  "${PROJECT_SOURCE_DIR}/../connectivity/lorawan/include/lorawan"
-  "${PROJECT_SOURCE_DIR}/../connectivity/lorawan/lorastack"
-  "${PROJECT_SOURCE_DIR}/../connectivity/lorawan/lorastack/mac"
-  "${PROJECT_SOURCE_DIR}/../connectivity/lorawan/lorastack/phy"
-  "${PROJECT_SOURCE_DIR}/../connectivity/lorawan"
-  "${PROJECT_SOURCE_DIR}/../connectivity/mbedtls"
-  "${PROJECT_SOURCE_DIR}/../connectivity/mbedtls/include"
+  "./target_h"
+  "../events/tests/UNITTESTS/target_h"
+  "../events/tests/UNITTESTS/target_h/equeue"
+  "./target_h/platform"
+  "./target_h/platform/cxxsupport"
+  "./target_h/drivers"
+  "./target_h/rtos/include"
+  "./stubs"
+  "../"
+  "../features"
+  "../platform/include"
+  "../platform/include/platform"
+  "../platform/mbed-trace/include"
+  "../storage/filesystem/littlefs/include"
+  "../storage/filesystem/fat/include"
+  "../storage/blockdevice/include"
+  "../storage/filesystem/include"
+  "../storage/kvstore/include"
+  "../storage/kvstore/kv_config"
+  "../storage/kvstore/kv_config/include"
+  "../storage/kvstore/tdbstore/include"
+  "../storage/kvstore/filesystemstore/include"
+  "../storage/kvstore/kvstore_global_api/include"
+  "../drivers"
+  "../drivers/include"
+  "../drivers/include/drivers"
+  "../drivers/include/drivers/internal"
+  "../hal"
+  "../hal/include"
+  "../events/include"
+  "../events/include/events/internal"
+  "../events/source"
+  "../rtos/include"
+  "../features/frameworks"
+  "../connectivity/libraries/nanostack-libservice"
+  "../connectivity/libraries/nanostack-libservice/mbed-client-libservice"
+  "../connectivity/netsocket/include"
+  "../features/filesystem/fat"
+  "../features/filesystem/fat/ChaN"
+  "../features/filesystem/bd"
+  "../features/filesystem/"
+  "../features/filesystem/littlefs"
+  "../features/filesystem/littlefs/littlefs"
+  "../connectivity/cellular/include/cellular/framework/API"
+  "../connectivity/cellular/include/cellular/framework/AT"
+  "../connectivity/cellular/include/cellular/framework/device"
+  "../connectivity/cellular/include/cellular/framework"
+  "../connectivity/cellular/include/cellular/framework/common"
+  "../connectivity"
+  "../connectivity/lorawan/include/lorawan"
+  "../connectivity/lorawan/lorastack"
+  "../connectivity/lorawan/lorastack/mac"
+  "../connectivity/lorawan/lorastack/phy"
+  "../connectivity/lorawan"
+  "../connectivity/mbedtls"
+  "../connectivity/mbedtls/include"
 )
 
 # Create a list for test suites.
@@ -191,7 +158,7 @@ foreach(testfile ${unittest-file-list})
 
   file(RELATIVE_PATH
        TEST_SUITE_NAME # output
-       "${PROJECT_SOURCE_DIR}/.." # root
+       "${PROJECT_SOURCE_DIR}" # root
        ${TEST_SUITE_DIR} #abs dirpath
   )
 
@@ -199,7 +166,7 @@ foreach(testfile ${unittest-file-list})
 
   set(TEST_SUITES ${TEST_SUITES} ${TEST_SUITE_NAME})
 
-  set(LIBS_TO_BE_LINKED gmock_main)
+  set(LIBS_TO_BE_LINKED gmock_main ${CMAKE_THREAD_LIBS_INIT})
 
   # Build directories list
   set(BUILD_DIRECTORIES)

--- a/tools/cmake/README.md
+++ b/tools/cmake/README.md
@@ -96,7 +96,20 @@ $ mbedtools configure -t <TOOLCHAIN> -m <MBED_TARGET>
   ```
   touch mbed-os.lib && mkdir cmake_build && cd cmake_build && cmake .. -G Ninja -DMBED_BAREMETAL_GREENTEA_TEST=ON && cmake --build .
   ```
-
 Notes:
 * These steps will change when `mbedtools` implements a sub-command to invoke Greentea tests
 * Some Greentea tests require specific application configuration files in order to build and run successfully. For example, the `connectivity/mbedtls/tests/TESTS/mbedtls/sanity` test requires the configuration file found at `TESTs/configs/experimental.json`.
+
+## How to build and run a unit test
+
+Install prerequisites suggested in the previous section and follow the below steps:
+* Run the following command to build the unit test from mbed-os root directory:
+  ```
+  mkdir cmake_build && cmake -GNinja -DCMAKE_UNIT_TESTING=1 -B cmake_build && cmake --build cmake_build
+  ```
+  Note: Cmake `CMAKE_UNIT_TESTING` command line option is added in `mbed-os/CMakeLists.txt` to select unittest build
+
+* Run the following command to run the test using CTest:
+  ```
+  cd cmake_build/UNITTESTS && /usr/local/bin/ctest --force-new-ctest-process -V -D ExperimentalTest
+  ```


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
- Added new CMake command line macro CMAKE_UNIT_TESTING in mbed-os/CMakeLists.txt file to add unittest directory which will allow us to build the unittest from mbed os root directory 
- Used fetch content module to fetch google test instead of using .in config file

Note: This is breaking change:
- CMake issue warnings as I have moved all below CMake config from UNITTESTS/CMakeLists.txt into mbed-os/CMakeLists.txt
```
    set(PROJECT_NAME unittests)
    set(LIB_NAME MbedOS)
    project(${PROJECT_NAME})
```
- I have modified the `unittest-includes-base` to add `UNITTESTS` directory as we try to run unittest from mbed os root directory, so Mbed CLI 1 fails with missing headers when we run a unit test using `mbed test --unittests command`


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@hugueskamba @0xc170
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
